### PR TITLE
[Misc] Update WebViewer v11

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-Copyright 2023 Apryse Software Inc. All rights reserved.
+Copyright 2024 Apryse Software Inc. All rights reserved.
 WebViewer React UI project/codebase or any derived works is only permitted in solutions with an active commercial Apryse WebViewer license. For exact licensing terms refer to your commercial WebViewer license. For use in other scenario, contact sales@apryse.com.

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-Copyright 2018 PDFTron Systems Inc. All rights reserved.
-WebViewer React UI project/codebase or any derived works is only permitted in solutions with an active commercial PDFTron WebViewer license. For exact licensing terms please refer to your commercial WebViewer license. For use in other scenario, please contact sales@pdftron.com
+Copyright 2023 Apryse Software Inc. All rights reserved.
+WebViewer React UI project/codebase or any derived works is only permitted in solutions with an active commercial Apryse WebViewer license. For exact licensing terms refer to your commercial WebViewer license. For use in other scenario, contact sales@apryse.com.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
 # WebViewer - AngularJS sample
 
-[WebViewer](https://www.pdftron.com/webviewer) is a powerful JavaScript-based PDF Library that's part of the [PDFTron PDF SDK](https://www.pdftron.com). It provides a slick out-of-the-box responsive UI that interacts with the core library to view, annotate and manipulate PDFs that can be embedded into any web project.
+[WebViewer](https://www.pdftron.com/webviewer) is a powerful JavaScript-based PDF Library that is part of the [Apryse SDK](https://www.pdftron.com). It provides a slick out-of-the-box responsive UI that interacts with the core library to view, annotate, and manipulate PDFs that can be embedded into any web project.
 
 ![WebViewer UI](https://www.pdftron.com/downloads/pl/webviewer-ui.png)
 
-This repo is specifically designed for any users interested in integrating WebViewer into AngularJS project. See [AngularJS.org](https://angularjs.org) for more information.
+This repo is specifically designed for any users interested in integrating WebViewer into [AngularJS](https://angularjs.org).
 
 ## Initial setup
 
-Before you begin, make sure your development environment includes [Node.js](https://nodejs.org/en/).
+Before you begin, make sure your development environment includes:
+
+1. [Node.js](https://nodejs.org/en).
+2. IDE used in this sample is Visual Studio Code.
+3. [GitHub command line](https://github.com/git-guides/install-git) `git`.
+4. Angular CLI: `npm install -g @angular/cli`. If an unsupported engine message appears, make sure to install a compatible NodeJS version.
 
 ## Install
 
 ```
-git clone https://github.com/PDFTron/webviewer-angularjs-sample.git
+gh repo clone ApryseSDK/webviewer-angularjs-sample
 cd webviewer-angularjs-sample
 npm install
 ```
@@ -26,13 +31,9 @@ npm start
 
 Navigate to `http://localhost:3000/`. The app will automatically reload if you change any of the source files.
 
-## WebViewer APIs
-
-See [API documentation](https://www.pdftron.com/documentation/web/guides/ui/apis).
-
 ## Enabling full API
 
-PDFNetJS Full is a complete browser side PDF SDK, unlocking viewing, parsing and editing of PDF files. To enable full API, you can modify constructor in components.js:
+Webviewer Full API is a complete browser side PDF SDK, unlocking viewing, parsing and editing of PDF files. To enable full API, you can modify constructor in components.js:
 
 ```diff
 WebViewer({
@@ -42,13 +43,22 @@ WebViewer({
 }, document.getElementById('viewer'))
 ```
 
-You can refer to this [guide for more information](https://www.pdftron.com/documentation/web/guides/full-api)
+Visit Apryse's [WebViewer](https://docs.apryse.com/documentation/web/) page to see what else you can do with the WebViewer.
+
+## WebViewer APIs
+
+* [@pdftron/webviewer API documentation](https://docs.apryse.com/api/web/global.html#WebViewer__anchor)
+* [@pdftron/webviewer-angularjs](https://github.com/ApryseSDK/webviewer-angularjs-sample)
+
+## Showcase
+
+Refer to a running sample on Apryse SDK [showcase page](https://showcase.apryse.com/).
 
 ## Contributing
 
-See [contributing](./CONTRIBUTING.md).
+Any submission to this repo is governed by these [guidelines](/CONTRIBUTING.md).
+
 
 ## License
 
-See [license](./LICENSE).
-![](https://onepixel.pdftron.com/webviewer-angularjs-sample)
+For licensing, refer to [License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebViewer - AngularJS sample
 
-[WebViewer](https://www.pdftron.com/webviewer) is a powerful JavaScript-based PDF Library that is part of the [Apryse SDK](https://www.pdftron.com). It provides a slick out-of-the-box responsive UI that interacts with the core library to view, annotate, and manipulate PDFs that can be embedded into any web project.
+[WebViewer](https://apryse.com/products/webviewer) is a powerful JavaScript-based PDF Library that is part of the [Apryse SDK](https://apryse.com/). It provides a slick out-of-the-box responsive UI that interacts with the core library to view, annotate, and manipulate PDFs that can be embedded into any web project.
 
 ![WebViewer UI](https://www.pdftron.com/downloads/pl/webviewer-ui.png)
 
@@ -33,7 +33,7 @@ Navigate to `http://localhost:3000/`. The app will automatically reload if you c
 
 ## Enabling full API
 
-Webviewer Full API is a complete browser side PDF SDK, unlocking viewing, parsing and editing of PDF files. To enable full API, you can modify constructor in components.js:
+WebViewer Full API is a complete browser side PDF SDK, unlocking viewing, parsing and editing of PDF files. To enable full API, you can modify constructor in components.js:
 
 ```diff
 WebViewer({

--- a/app/components.js
+++ b/app/components.js
@@ -12,22 +12,22 @@ angular.module('components', [])
           initialDoc: 'https://pdftron.s3.amazonaws.com/downloads/pl/demo-annotated.pdf',
           // initialDoc: '/path/to/my/file.pdf',  // You can also use documents on your server
         }, document.getElementById('viewer'))
-        .then(function(instance) {
-          const docViewer = instance.Core.documentViewer;
-          const annotManager = instance.Core.annotationManager;
-          // call methods from instance, docViewer and annotManager as needed
+          .then(function(instance) {
+            const docViewer = instance.Core.documentViewer;
+            const annotManager = instance.Core.annotationManager;
+            // call methods from instance, docViewer and annotManager as needed
 
-          // you can also access major namespaces from the instance as follows:
-          // const Tools = instance.Core.Tools;
-          // const Annotations = instance.Core.Annotations;
+            // you can also access major namespaces from the instance as follows:
+            // const Tools = instance.Core.Tools;
+            // const Annotations = instance.Core.Annotations;
 
-          // change to dark theme
-          instance.UI.setTheme('dark');
+            // change to dark theme
+            instance.UI.setTheme('dark');
 
-          docViewer.addEventListener('documentLoaded', function() {
-            // call methods relating to the loaded document
+            docViewer.addEventListener('documentLoaded', function() {
+              // call methods relating to the loaded document
+            });
           });
-        });
       },
       template: "<div id='viewer' style='width: 100%; height: 100%; margin: 0 auto;'></div>",
       replace: true

--- a/app/components.js
+++ b/app/components.js
@@ -13,18 +13,18 @@ angular.module('components', [])
           // initialDoc: '/path/to/my/file.pdf',  // You can also use documents on your server
         }, document.getElementById('viewer'))
         .then(function(instance) {
-          var docViewer = instance.docViewer;
-          var annotManager = instance.annotManager;
+          const docViewer = instance.Core.documentViewer;
+          const annotManager = instance.Core.annotationManager;
           // call methods from instance, docViewer and annotManager as needed
 
           // you can also access major namespaces from the instance as follows:
-          // var Tools = instance.Tools;
-          // var Annotations = instance.Annotations;
+          // const Tools = instance.Core.Tools;
+          // const Annotations = instance.Core.Annotations;
 
           // change to dark theme
-          instance.setTheme('dark');
+          instance.UI.setTheme('dark');
 
-          docViewer.on('documentLoaded', function() {
+          docViewer.addEventListener('documentLoaded', function() {
             // call methods relating to the loaded document
           });
         });

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "https://github.com/ApryseSDK/webviewer-angularjs-sample.git"
   },
   "author": "Apryse Software Inc."
 }

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
   "name": "webviewer-angularjs-sample",
   "version": "1.0.0",
+  "description": "Apryse WebViewer",
   "scripts": {
     "start": "npm run server",
     "server": "./node_modules/.bin/supervisor -k -e html,js -i .git/,node_modules/ -- server.js",
-    "postinstall": "npm run download-webviewer",
-    "download-webviewer": "npx @pdftron/webviewer-downloader --webviewerLocation app/lib"
+    "postinstall": "node tools/copy-webviewer-files.js"
   },
   "devDependencies": {
     "body-parser": "1.18.3",
     "express": "^4.16.3",
     "morgan": "^1.9.1",
-    "opn": "^5.3.0",
     "supervisor": "0.12.0",
-    "@pdftron/webviewer-downloader": "^1.1.0"
+    "fs-extra": "^9.0.0",
+    "@pdftron/webviewer": "^11.0.0"
   },
   "repository": {
     "type": "git",
     "url": ""
   },
-  "author": "PDFTron Systems Inc."
+  "author": "Apryse Software Inc."
 }

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "postinstall": "node tools/copy-webviewer-files.js"
   },
   "devDependencies": {
-    "body-parser": "1.18.3",
-    "express": "^4.16.3",
+    "body-parser": "^1.20.3",
+    "express": "^4.21.0",
     "morgan": "^1.9.1",
     "supervisor": "0.12.0",
-    "fs-extra": "^9.0.0",
+    "fs-extra": "^11.2.0",
     "@pdftron/webviewer": "^11.0.0"
   },
   "repository": {

--- a/tools/copy-webviewer-files.js
+++ b/tools/copy-webviewer-files.js
@@ -1,0 +1,13 @@
+const fs = require('fs-extra');
+
+const copyFiles = async () => {
+  try {
+    await fs.copy('./node_modules/@pdftron/webviewer/public', './app/lib');
+    await fs.copy('./node_modules/@pdftron/webviewer/webviewer.min.js', './app/lib/webviewer.min.js');
+    console.log('WebViewer files copied over successfully');
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+copyFiles();


### PR DESCRIPTION
- Remove `@pdftron/webviewer-downloader`
- Add `@pdftron/webviewer` instead and setup the postinstall script to copy over the lib

The app looks like this 
<img width="1673" alt="image" src="https://github.com/user-attachments/assets/d961ed11-680e-454f-b32b-664b0e2a5146">

Also cherry pick from another PR #2:

> 1. `app\components.js` updated calls to members that were missing the 'UI', 'Core', changed `docViewer.on(` to `docViewer.addEventListener`, console output for debugging, and updated indentation styles.
> 
> 2.  `package.json` server script does not work with forward slashes for package location, changed to double backslashes. Also updated the package versions to use latest.
> 
> 3. `README.MD` updated to use Apryse links, and added sections to link up to documentation and showcase sample.
> 
> 4. `LICENSE` updated to use similar statement as in recent edits to other projects.


