### PR TITLE
Updated WebViewer to v11.2 and call the locally-installed dependency command directly, without the "./node_modules/.bin" prefix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Apryse WebViewer",
   "scripts": {
     "start": "npm run server",
-    "server": "./node_modules/.bin/supervisor -k -e html,js -i .git/,node_modules/ -- server.js",
+    "server": "supervisor -k -e html,js -i .git/,node_modules/ -- server.js",
     "postinstall": "node tools/copy-webviewer-files.js"
   },
   "devDependencies": {
@@ -13,7 +13,7 @@
     "morgan": "^1.9.1",
     "supervisor": "0.12.0",
     "fs-extra": "^11.2.0",
-    "@pdftron/webviewer": "^11.0.0"
+    "@pdftron/webviewer": "^11.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. Upgrade WebViewer version
2. server script call the locally-installed supervisor command directly -- without the "./node_modules/.bin" prefix -- based on npm documentation https://docs.npmjs.com/cli/v9/commands/npm-run-script?v=true